### PR TITLE
Make packages with x.y.z.w version download from Pypy

### DIFF
--- a/data/projects.ini
+++ b/data/projects.ini
@@ -450,6 +450,7 @@ description_short: Python module to read with PE (Portable Executable) files.
 description_long:  Python module to read and work with Portable Executable
     (aka PE) files. Most of the information in the PE Header is accessible, as
     well as all the sections, section's information and data.
+patches: https://drive.google.com/file/d/0B-9s0U6ZgGh4TXFFemM4OWZDVFk/view?usp=sharing
 
 [protobuf]
 build_system: setup_py

--- a/l2tdevtools/download_helper.py
+++ b/l2tdevtools/download_helper.py
@@ -609,7 +609,8 @@ class PyPiDownloadHelper(ProjectDownloadHelper):
   _VERSION_EXPRESSIONS = [
       u'[0-9]+[.][0-9]+',
       u'[0-9]+[.][0-9]+a[0-9]',
-      u'[0-9]+[.][0-9]+[.][0-9]+']
+      u'[0-9]+[.][0-9]+[.][0-9]+',
+      u'[0-9]+[.][0-9]+[.][0-9]+[.][0-9]+']
 
   def GetLatestVersion(self, project_name):
     """Retrieves the latest version number for a given project name.


### PR DESCRIPTION
Commit 641aef8: Required for dpkt-1.8.6.2.tar.gz
Commit 2b9ca30: pefile cannot be built from the release package, small patch required..
--- pefile.py.orig      2015-06-12 12:39:52.780304356 -0700
+++ pefile.py   2015-06-12 12:41:44.382797369 -0700
@@ -20,9 +20,9 @@
 the root of the distribution archive.
 """

-__revision__ = "$LastChangedRevision$"
+__revision__ = "139"
 __author__ = 'Ero Carrera'
-__version__ = '1.2.10-%d' % int( __revision__[21:-2] )
+__version__ = '1.2.10-%d' % int( __revision__ )
 __contact__ = 'ero.carrera@gmail.com'
