### PR TITLE
Don't use _'ed versions of the package name for .install file

### DIFF
--- a/l2tdevtools/dpkg_files.py
+++ b/l2tdevtools/dpkg_files.py
@@ -697,7 +697,8 @@ class DPKGBuildFilesGenerator(object):
               template_file, template_data, template_values, output_filename)
 
       if os.path.isdir('scripts') or os.path.isdir('tools'):
-        output_filename = '{0:s}-tools.install'.format(self._GetPackageName())
+        install_package_name = self._GetPackageName()
+        output_filename = '{0:s}-tools.install'.format(install_package_name)
         output_filename = os.path.join(dpkg_path, output_filename)
         self._GenerateFile(
             None, self._INSTALL_TEMPLATE_PYTHON_TOOLS, template_values,

--- a/l2tdevtools/dpkg_files.py
+++ b/l2tdevtools/dpkg_files.py
@@ -697,7 +697,7 @@ class DPKGBuildFilesGenerator(object):
               template_file, template_data, template_values, output_filename)
 
       if os.path.isdir('scripts') or os.path.isdir('tools'):
-        output_filename = '{0:s}-tools.install'.format(package_name)
+        output_filename = '{0:s}-tools.install'.format(self._GetPackageName())
         output_filename = os.path.join(dpkg_path, output_filename)
         self._GenerateFile(
             None, self._INSTALL_TEMPLATE_PYTHON_TOOLS, template_values,


### PR DESCRIPTION
When building a .deb package, the PACKAGE-toos.install file shouldn't have its '-' changed into '_', otherwise the final package will lack pointers to usr/bin and be an empty shell:

Without the patch:
```
$ PYTHONPATH=. python tools/build.py --build-directory=/tmp/build/  --project docker-explorer dpkg
$ dpkg --contents /tmp/build/docker-explorer-tools_20190310-1_all.deb
drwxr-xr-x root/root         0 2019-03-19 17:45 ./
drwxr-xr-x root/root         0 2019-03-19 17:45 ./usr/
drwxr-xr-x root/root         0 2019-03-19 17:45 ./usr/share/
drwxr-xr-x root/root         0 2019-03-19 17:45 ./usr/share/doc/
drwxr-xr-x root/root         0 2019-03-19 17:45 ./usr/share/doc/docker-explorer-tools/
-rw-r--r-- root/root       161 2019-03-19 17:45 ./usr/share/doc/docker-explorer-tools/changelog.Debian.gz
-rw-r--r-- root/root     11358 2019-03-19 17:45 ./usr/share/doc/docker-explorer-tools/copyright
```
After the patch:
```
$ dpkg --contents /tmp/build/docker-explorer-tools_20190310-1_all.deb
drwxr-xr-x root/root         0 2019-03-19 17:54 ./
drwxr-xr-x root/root         0 2019-03-19 17:54 ./usr/
drwxr-xr-x root/root         0 2019-03-19 17:54 ./usr/bin/
-rwxr-xr-x root/root     13365 2019-03-19 17:54 ./usr/bin/de.py
drwxr-xr-x root/root         0 2019-03-19 17:54 ./usr/share/
drwxr-xr-x root/root         0 2019-03-19 17:54 ./usr/share/doc/
drwxr-xr-x root/root         0 2019-03-19 17:54 ./usr/share/doc/docker-explorer-tools/
-rw-r--r-- root/root       160 2019-03-19 17:54 ./usr/share/doc/docker-explorer-tools/changelog.Debian.gz
-rw-r--r-- root/root         1 2019-03-19 17:54 ./usr/share/doc/docker-explorer-tools/copyright
```
