### PR TITLE
Changes to configparser dpkg build configuration

### DIFF
--- a/data/dpkg_templates/python-configparser.install
+++ b/data/dpkg_templates/python-configparser.install
@@ -1,4 +1,3 @@
-usr/lib/python2*/dist-packages/*.pth
 usr/lib/python2*/dist-packages/*.py
 usr/lib/python2*/dist-packages/backports/configparser/*
 usr/lib/python2*/dist-packages/configparser*.egg-info/*


### PR DESCRIPTION
Ignore .pth files when determining dpkg package contents