### PR TITLE
Changed AppVeyor CI tests to use Python 3.8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,18 +2,24 @@ environment:
   matrix:
   - TARGET: unittests
     MACHINE_TYPE: "x86"
-    PYTHON: "C:\\Python37"
-    PYTHON_VERSION: "3.7"
+    PYTHON: "C:\\Python38"
+    PYTHON_VERSION: "3.8"
+    L2TBINARIES_TRACK: "testing"
   - TARGET: unittests
     MACHINE_TYPE: "amd64"
-    PYTHON: "C:\\Python37-x64"
-    PYTHON_VERSION: "3.7"
+    PYTHON: "C:\\Python38-x64"
+    PYTHON_VERSION: "3.8"
+    L2TBINARIES_TRACK: "testing"
 
 install:
 - cmd: '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86 /release'
-- cmd: "%PYTHON%\\python.exe -m pip install -U pip setuptools wheel"
-- cmd: "%PYTHON%\\python.exe -m pip install pywin32 WMI"
-- cmd: "%PYTHON%\\python.exe %PYTHON%\\Scripts\\pywin32_postinstall.py -install"
+- cmd: '"%PYTHON%\\python.exe" -m pip install -U pip setuptools wheel'
+- cmd: '"%PYTHON%\\python.exe" -m pip install pywin32 WMI'
+- cmd: '"%PYTHON%\\python.exe" "%PYTHON%\\Scripts\\pywin32_postinstall.py" -install'
+- cmd: if [%PYTHON_VERSION%]==[3.8] (
+    mkdir dependencies &&
+    set PYTHONPATH=..\l2tdevtools &&
+    "%PYTHON%\\python.exe" ..\l2tdevtools\tools\update.py --download-directory dependencies --machine-type %MACHINE_TYPE% --msi-targetdir "%PYTHON%" --track "%L2TBINARIES_TRACK%" mock pbr six )
 
 build: off
 

--- a/data/templates/appveyor.yml/environment
+++ b/data/templates/appveyor.yml/environment
@@ -2,9 +2,11 @@ environment:
   matrix:
   - TARGET: unittests
     MACHINE_TYPE: "x86"
-    PYTHON: "C:\\Python37"
-    PYTHON_VERSION: "3.7"
+    PYTHON: "C:\\Python38"
+    PYTHON_VERSION: "3.8"
+    L2TBINARIES_TRACK: "testing"
   - TARGET: unittests
     MACHINE_TYPE: "amd64"
-    PYTHON: "C:\\Python37-x64"
-    PYTHON_VERSION: "3.7"
+    PYTHON: "C:\\Python38-x64"
+    PYTHON_VERSION: "3.8"
+    L2TBINARIES_TRACK: "testing"

--- a/data/templates/appveyor.yml/install_windows_python3
+++ b/data/templates/appveyor.yml/install_windows_python3
@@ -1,4 +1,4 @@
-- cmd: if [%PYTHON_VERSION%]==[3.7] (
+- cmd: if [%PYTHON_VERSION%]==[3.8] (
     mkdir dependencies &&
     set PYTHONPATH=..\l2tdevtools &&
-    "%PYTHON%\\python.exe" ..\l2tdevtools\tools\update.py --download-directory dependencies --machine-type %MACHINE_TYPE% --msi-targetdir "%PYTHON%" --track dev ${python3_dependencies} )
+    "%PYTHON%\\python.exe" ..\l2tdevtools\tools\update.py --download-directory dependencies --machine-type %MACHINE_TYPE% --msi-targetdir "%PYTHON%" --track "%L2TBINARIES_TRACK%" ${python3_dependencies} )


### PR DESCRIPTION
Changed AppVeyor CI tests to use Python 3.8
