### PR TITLE
Updated MacOS CI tests to use Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,10 +60,10 @@ jobs:
     python: 3.8
     services:
     - docker
-  - name: "MacOS 10.14 with Python 3.7 (tox)"
-    env: TOXENV="py37"
+  - name: "MacOS 10.14 with Python 3.8 (tox)"
+    env: TOXENV="py38"
     os: osx
-    osx_image: xcode10
+    osx_image: xcode11
   - name: "Dockerfile"
     env: TARGET="dockerfile"
     group: edge

--- a/data/templates/.travis.yml/jobs_macos
+++ b/data/templates/.travis.yml/jobs_macos
@@ -1,4 +1,4 @@
-  - name: "MacOS 10.14 with Python 3.7 (tox)"
-    env: TOXENV="py37"
+  - name: "MacOS 10.14 with Python 3.8 (tox)"
+    env: TOXENV="py38"
     os: osx
-    osx_image: xcode10
+    osx_image: xcode11

--- a/tests/download_helpers/github.py
+++ b/tests/download_helpers/github.py
@@ -101,7 +101,7 @@ class LibyalGitHubReleasesDownloadHelperTest(test_lib.BaseTestCase):
   _PROJECT_ORGANIZATION = 'libyal'
   _PROJECT_NAME = 'libevt'
   _PROJECT_STATUS = 'alpha'
-  _PROJECT_VERSION = '20200418'
+  _PROJECT_VERSION = '20200708'
 
   @classmethod
   def setUpClass(cls):


### PR DESCRIPTION
Updated MacOS CI tests to use Python 3.8